### PR TITLE
additional checks for work events management

### DIFF
--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
@@ -174,7 +174,8 @@ class WorkEventApiImpl: WorkEventsApi, AbstractApi() {
      * - Type of shift start/end cannot be changed
      * - Cannot have two start or end events in the same shift
      * - Events apart from shift start or end cannot be moved outside the shift
-     * - Shift start event must be before shift end event
+     * - Shift start cannot be later than the next event
+     * - Shift end cannot be earlier than the previous event
      *
      * @param workEvent work event
      * @param newWorkEventData new work event data

--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
@@ -173,8 +173,9 @@ class WorkEventApiImpl: WorkEventsApi, AbstractApi() {
      * Checks if work event is editable. Checks the condtions:
      * - Type of shift start/end cannot be changed
      * - Cannot have two start or end events in the same shift
-     * - Not start or end events cannot be moved outside the shift
-     * - Shift start event must be before shift end event
+     * - Events apart from shift start or end cannot be moved outside the shift
+     * - Shift start cannot be later than the next event
+     * - Shift end cannot be earlier than the previous event
      *
      * @param workEvent work event
      * @param newWorkEventData new work event data

--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
@@ -173,9 +173,8 @@ class WorkEventApiImpl: WorkEventsApi, AbstractApi() {
      * Checks if work event is editable. Checks the condtions:
      * - Type of shift start/end cannot be changed
      * - Cannot have two start or end events in the same shift
-     * - Events apart from shift start or end cannot be moved outside the shift
-     * - Shift start cannot be later than the next event
-     * - Shift end cannot be earlier than the previous event
+     * - Not start or end events cannot be moved outside the shift
+     * - Shift start event must be before shift end event
      *
      * @param workEvent work event
      * @param newWorkEventData new work event data

--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventApiImpl.kt
@@ -173,7 +173,7 @@ class WorkEventApiImpl: WorkEventsApi, AbstractApi() {
      * Checks if work event is editable. Checks the condtions:
      * - Type of shift start/end cannot be changed
      * - Cannot have two start or end events in the same shift
-     * - Not start or end events cannot be moved outside the shift
+     * - Events apart from shift start or end cannot be moved outside the shift
      * - Shift start event must be before shift end event
      *
      * @param workEvent work event

--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventController.kt
@@ -153,14 +153,12 @@ class WorkEventController {
     /**
      * Returns the shift start and end events for the work event's work shift (excluding the work event itself)
      *
-     * @param workEvent work event
+     * @param shiftEvents work events
      * @return pair of shift start and end events
      */
-    suspend fun getShiftStartEnd(workEvent: WorkEventEntity): Pair<WorkEventEntity?, WorkEventEntity?> {
-        val otherShiftEvents = list(employeeWorkShift = workEvent.workShift).first
-            .filter { it.id != workEvent.id }
-        val shiftStart = otherShiftEvents.find { it.workEventType == WorkEventType.SHIFT_START }
-        val shiftEnd = otherShiftEvents.find { it.workEventType == WorkEventType.SHIFT_END }
+    suspend fun getShiftStartEnd(shiftEvents: List<WorkEventEntity>): Pair<WorkEventEntity?, WorkEventEntity?> {
+        val shiftStart = shiftEvents.find { it.workEventType == WorkEventType.SHIFT_START }
+        val shiftEnd = shiftEvents.find { it.workEventType == WorkEventType.SHIFT_END }
         return Pair(shiftStart, shiftEnd)
     }
 

--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventController.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/workevents/WorkEventController.kt
@@ -81,7 +81,7 @@ class WorkEventController {
         val employeeId = UUID.fromString(employee.id)
         val latestWorkEvent = workEventRepository.findLatestWorkEvent(employeeId = employeeId)
 
-        val workShift = getWorkEventShift(latestWorkEvent, time, employeeId)
+        val workShift = getWorkEventShift(latestWorkEvent, workEventType, time, employeeId)
 
         val createdWorkEvent = workEventRepository.create(
             id = UUID.randomUUID(),
@@ -151,6 +151,51 @@ class WorkEventController {
     }
 
     /**
+     * Returns the shift start and end events for the work event's work shift (excluding the work event itself)
+     *
+     * @param workEvent work event
+     * @return pair of shift start and end events
+     */
+    suspend fun getShiftStartEnd(workEvent: WorkEventEntity): Pair<WorkEventEntity?, WorkEventEntity?> {
+        val otherShiftEvents = list(employeeWorkShift = workEvent.workShift).first
+            .filter { it.id != workEvent.id }
+        val shiftStart = otherShiftEvents.find { it.workEventType == WorkEventType.SHIFT_START }
+        val shiftEnd = otherShiftEvents.find { it.workEventType == WorkEventType.SHIFT_END }
+        return Pair(shiftStart, shiftEnd)
+    }
+
+    /**
+     * Checks if the time is within the shift bounds
+     *
+     * @param shiftStart shift start event
+     * @param shiftEnd shift end event
+     * @param time time to be checked
+     * @return true if the time is within the shift bounds, false otherwise
+     */
+    fun isWithinShiftBounds(shiftStart: WorkEventEntity?, shiftEnd: WorkEventEntity?, time: OffsetDateTime): Boolean {
+        val isAfterShiftStart = shiftStart == null || time.isAfter(shiftStart.time)
+        val isBeforeShiftEnd = shiftEnd == null || time.isBefore(shiftEnd.time)
+        return isAfterShiftStart && isBeforeShiftEnd
+    }
+
+    /**
+     * Checks if the work event is a duplicate start or end event
+     *
+     * @param shiftStart shift start event
+     * @param shiftEnd shift end event
+     * @param workEventType work event type to be compared
+     * @return true if the work event is a duplicate start or end event, false otherwise
+     */
+    fun isDuplicateStartOrEndEvent(
+        shiftStart: WorkEventEntity?,
+        shiftEnd: WorkEventEntity?,
+        workEventType: WorkEventType
+    ): Boolean {
+        return (shiftStart != null && workEventType == WorkEventType.SHIFT_START) ||
+            (shiftEnd != null && workEventType == WorkEventType.SHIFT_END)
+    }
+
+    /**
      * Recalculates the work shift date/start/end times based on its work events.
      * Finds the first work event in the shift and updates the shift date if needed
      *
@@ -180,15 +225,18 @@ class WorkEventController {
     }
 
     /**
-     * Returns the work shift for the work event, creates a new shift if needed
+     * Returns the work shift for the work event, creates a new shift if needed and updates/creates other work
+     * events related to shift starting and ending.
      *
      * @param latestWorkEvent latest work event
+     * @param workEventType work event type
      * @param workEventTime work event time
      * @param employeeId employee id
      * @return work shift
      */
     private suspend fun getWorkEventShift(
         latestWorkEvent: WorkEventEntity?,
+        workEventType: WorkEventType,
         workEventTime: OffsetDateTime,
         employeeId: UUID
     ): WorkShiftEntity {
@@ -202,10 +250,23 @@ class WorkEventController {
                 workEventRepository.persistSuspending(latestWorkEvent)
             }
 
-            workShiftController.create(
+            val newWorkShift = workShiftController.create(
                 employeeId = employeeId,
                 date = workEventTime.toLocalDate()
             )
+
+            // Create a new shift start event if the new event is not a shift start
+            if (workEventType != WorkEventType.SHIFT_START) {
+                workEventRepository.create(
+                    id = UUID.randomUUID(),
+                    workShiftEntity = newWorkShift,
+                    employeeId = employeeId,
+                    workEventType = WorkEventType.SHIFT_START,
+                    time = workEventTime.minusSeconds(1)
+                )
+            }
+
+            newWorkShift
         } else {
             latestWorkEvent!!.workShift
         }
@@ -219,7 +280,7 @@ class WorkEventController {
      * @param currentWorkEventTime current work event time
      * @return true if a new shift is required, false otherwise
      */
-    private fun requiresNewShift(
+    fun requiresNewShift(
         latestWorkEvent: WorkEventEntity?,
         currentWorkEventTime: OffsetDateTime
     ): Boolean {

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/WorkEventTestIT.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/WorkEventTestIT.kt
@@ -5,8 +5,7 @@ import fi.metatavu.vp.test.client.models.WorkEventType
 import fi.metatavu.vp.usermanagement.settings.DefaultTestProfile
 import io.quarkus.test.junit.QuarkusTest
 import io.quarkus.test.junit.TestProfile
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 import java.util.*
@@ -62,22 +61,25 @@ class WorkEventTestIT : AbstractFunctionalTest() {
         )
 
         val employee1Records = it.manager.workEvents.listWorkEvents(employee1.id)
-        assertEquals(3, employee1Records.size)
+        assertEquals(4, employee1Records.size) // 3 events + shift start
         val employee2Records = it.manager.workEvents.listWorkEvents(employee2.id)
-        assertEquals(1, employee2Records.size)
+        assertEquals(2, employee2Records.size) // 1 event + shift start
         val afterFilter = it.manager.workEvents.listWorkEvents(employee1.id, after = now.plusHours(2))
         assertEquals(2, afterFilter.size)
         val beforeFilter = it.manager.workEvents.listWorkEvents(employee1.id, before = now.plusHours(1))
-        assertEquals(1, beforeFilter.size)
+        assertEquals(2, beforeFilter.size)  // 1 event + shift start
+
+        it.manager.workEvents.addEmployeeShiftStartToCloseables(employeeId = employee1.id)
     }
 
     @Test
     fun testCreate() = createTestBuilder().use {
         val employee1 = it.manager.employees.createEmployee("1")
+        val now = OffsetDateTime.now()
 
         val data = WorkEvent(
             workEventType = WorkEventType.DRY,
-            time = OffsetDateTime.now().toString(),
+            time = now.toString(),
             employeeId = employee1.id!!
         )
         val created = it.manager.workEvents.createWorkEvent(
@@ -98,6 +100,45 @@ class WorkEventTestIT : AbstractFunctionalTest() {
             workEvent = data.copy(employeeId = UUID.randomUUID()),
             expectedStatus = 400
         )
+
+        //Check that shift start event was created automatically
+        val allEvents = it.manager.workEvents.listWorkEvents(employee1.id)
+        assertEquals(2, allEvents.size)
+        val shiftStart = allEvents.find { e -> e.workEventType == WorkEventType.SHIFT_START }
+        assertNotNull(shiftStart)
+
+        it.manager.workEvents.addEmployeeShiftStartToCloseables(employeeId = employee1.id)
+
+        // No adding shift end before shift start
+        it.manager.workEvents.assertCreateFail(
+            employeeId = employee1.id,
+            workEvent = created.copy(
+                workEventType = WorkEventType.SHIFT_END,
+                time = now.minusDays(10).toString()
+            ),
+            expectedStatus = 400
+        )
+        // No adding double shift start/end events
+        it.manager.workEvents.assertCreateFail(
+            employeeId = employee1.id,
+            workEvent = created.copy(
+                workEventType = WorkEventType.SHIFT_START,
+                time = now.plusDays(10).toString()
+            ),
+            expectedStatus = 400
+        )
+
+        // no adding events outside of shift start/end
+        it.manager.workEvents.assertCreateFail(
+            employeeId = employee1.id,
+            workEvent = created.copy(
+                workEventType = WorkEventType.SHIFT_END,
+                time = now.minusDays(10).toString()
+            ),
+            expectedStatus = 400
+        )
+
+        it.manager.workEvents.addEmployeeShiftStartToCloseables(employeeId = employee1.id)
     }
 
     @Test
@@ -112,6 +153,8 @@ class WorkEventTestIT : AbstractFunctionalTest() {
             )
         )
         val found = it.manager.workEvents.findWorkEvent(employee1.id, created.id!!)
+
+        it.manager.workEvents.addEmployeeShiftStartToCloseables(employeeId = employee1.id)
 
         assertEquals(created.id, found.id)
         assertEquals(created.workEventType, found.workEventType)
@@ -134,18 +177,20 @@ class WorkEventTestIT : AbstractFunctionalTest() {
             )
         )
         val updateData = created.copy(
-            workEventType = WorkEventType.MEAT_CELLAR,
+            workEventType = WorkEventType.SHIFT_END,
             time = OffsetDateTime.now().toString()
         )
-        val updated = it.manager.workEvents.updateWorkEvent(employee1.id, created.id!!, updateData)
+        val updatedEndEvent = it.manager.workEvents.updateWorkEvent(employee1.id, created.id!!, updateData)
 
-        assertEquals(updateData.id, updated.id)
-        assertEquals(updateData.workEventType, updated.workEventType)
+        it.manager.workEvents.addEmployeeShiftStartToCloseables(employeeId = employee1.id)
+
+        assertEquals(updateData.id, updatedEndEvent.id)
+        assertEquals(updateData.workEventType, updatedEndEvent.workEventType)
         assertEquals(
             OffsetDateTime.parse(updateData.time).toEpochSecond(),
-            OffsetDateTime.parse(updated.time).toEpochSecond()
+            OffsetDateTime.parse(updatedEndEvent.time).toEpochSecond()
         )
-        assertEquals(updateData.employeeId, updated.employeeId)
+        assertEquals(updateData.employeeId, updatedEndEvent.employeeId)
 
         it.manager.workEvents.assertUpdateFail(
             employeeId = employee1.id,
@@ -153,6 +198,39 @@ class WorkEventTestIT : AbstractFunctionalTest() {
             workEvent = updateData.copy(employeeId = UUID.randomUUID()),
             expectedStatus = 400
         )
+
+        // Cannot update shift start/end event types
+        it.manager.workEvents.assertUpdateFail(
+            employeeId = employee1.id,
+            id = created.id,
+            workEvent = updateData.copy(workEventType = WorkEventType.SHIFT_START),
+            expectedStatus = 400
+        )
+
+        // cannot update event to be outside of shift start/end
+        it.manager.workEvents.assertUpdateFail(
+            employeeId = employee1.id,
+            id = created.id,
+            workEvent = created.copy(time = OffsetDateTime.now().plusDays(10).toString()),
+            expectedStatus = 400
+        )
+
+        // cannot update event to have doulbe shift start/end events
+        it.manager.workEvents.assertUpdateFail(
+            employeeId = employee1.id,
+            id = created.id,
+            workEvent = created.copy(workEventType = WorkEventType.SHIFT_START),
+            expectedStatus = 400
+        )
+
+        // cannot update shift end event to be before shift start
+        it.manager.workEvents.assertUpdateFail(
+            employeeId = employee1.id,
+            id = updatedEndEvent.id!!,
+            workEvent = updatedEndEvent.copy(time = OffsetDateTime.now().minusDays(10).toString()),
+            expectedStatus = 400
+        )
+
     }
 
     @Test
@@ -166,9 +244,15 @@ class WorkEventTestIT : AbstractFunctionalTest() {
                 employeeId = employee1.id
             )
         )
-        it.manager.workEvents.deleteWorkEvent(employee1.id, created.id!!)
         val all = it.manager.workEvents.listWorkEvents(employee1.id)
-        assertEquals(0, all.size)
+        assertEquals(2, all.size)
+
+        // Cannot delete shift start/end events if there are other events present
+        val shiftCreate = all.find { e -> e.workEventType == WorkEventType.SHIFT_START }!!
+        it.manager.workEvents.assertDeleteFail(employee1.id, shiftCreate.id!!, 400)
+
+        it.manager.workEvents.deleteWorkEvent(employee1.id, created.id!!)
+        it.manager.workEvents.deleteWorkEvent(employee1.id, shiftCreate.id)
     }
 
 }

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/WorkEventTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/WorkEventTestBuilderResource.kt
@@ -5,6 +5,7 @@ import fi.metatavu.vp.test.client.apis.WorkEventsApi
 import fi.metatavu.vp.test.client.infrastructure.ApiClient
 import fi.metatavu.vp.test.client.infrastructure.ClientException
 import fi.metatavu.vp.test.client.models.WorkEvent
+import fi.metatavu.vp.test.client.models.WorkEventType
 import fi.metatavu.vp.usermanagement.TestBuilder
 import fi.metatavu.vp.usermanagement.settings.ApiTestSettings
 import org.junit.Assert
@@ -26,10 +27,12 @@ class WorkEventTestBuilderResource(
 
 
     override fun clean(t: WorkEvent) {
-        api.deleteEmployeeWorkEvent(
-            t.employeeId,
-            t.id!!
-        )
+        try {
+            api.deleteEmployeeWorkEvent(
+                t.employeeId,
+                t.id!!
+            )
+        } catch (_: ClientException) { }
     }
 
     override fun getApi(): WorkEventsApi {
@@ -140,6 +143,35 @@ class WorkEventTestBuilderResource(
         api.deleteEmployeeWorkEvent(employeeId, id)
         removeCloseable {
             it is WorkEvent && it.id == id
+        }
+    }
+
+    /**
+     * Asserts that event deletion fails with status
+     *
+     * @param employeeId employee id
+     * @param id id
+     * @param expectedStatus expected error code
+     */
+    fun assertDeleteFail(employeeId: UUID, id: UUID, expectedStatus: Int) {
+        try {
+            api.deleteEmployeeWorkEvent(employeeId, id)
+            Assert.fail(String.format("Expected delete to fail with status %d", expectedStatus))
+        } catch (ex: ClientException) {
+            assertClientExceptionStatus(expectedStatus, ex)
+        }
+    }
+
+    /**
+     * Adds employee shift start to closeables
+     *
+     * @param employeeId employee id
+     */
+    fun addEmployeeShiftStartToCloseables(employeeId: UUID) {
+        api.listEmployeeWorkEvents(employeeId = employeeId).forEach { event ->
+            if (event.workEventType == WorkEventType.SHIFT_START) {
+                addClosable(event)
+            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/Metatavu/vp-kuljetus-user-management-service-api/issues/41

Changes:
Limitations to work event creation:

1. every first event in a shift unless it is a shift start creates a shift end event with time -1 second 
2. duplicate shift start or shift end events cannot be created 
3. Normal (not start or end) cannot be created outside the shift
4. Shift start event must be before shift end event

Limitations to work event updates:

1. Type of shift start/end cannot be changed
2. Cannot have two start or end events in the same shift
3. Normal (not start or end) events cannot be moved outside the shift
4. Shift start event cannot be moved before shift end event

Limitations to work event deletion:

1. shift start, shift end cannot be removed if there are other events in the shift. 