### PR TITLE
Feature 70 api key names

### DIFF
--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/clientapps/ClientAppApiImpl.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/clientapps/ClientAppApiImpl.kt
@@ -30,7 +30,7 @@ class ClientAppApiImpl: ClientAppsApi, AbstractApi() {
 
     @WithTransaction
     override fun createClientApp(clientApp: ClientApp): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDriverAppKey != driverAppKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
 
         // Check if client app already exists with same device id
         clientAppController.find(clientApp.deviceId)?.let {
@@ -67,8 +67,8 @@ class ClientAppApiImpl: ClientAppsApi, AbstractApi() {
 
 
     override fun findClientApp(clientAppId: UUID): Uni<Response> = withCoroutineScope {
-        if (loggedUserId == null && requestApiKey == null) return@withCoroutineScope createUnauthorized(UNAUTHORIZED)
-        if (requestApiKey != null && requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (loggedUserId == null && requestDriverAppKey == null) return@withCoroutineScope createUnauthorized(UNAUTHORIZED)
+        if (requestDriverAppKey != null && requestDriverAppKey != driverAppKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
         if (loggedUserId != null && !hasRealmRole(MANAGER_ROLE)) return@withCoroutineScope createForbidden(FORBIDDEN)
 
         val foundClientApp = clientAppController.find(clientAppId) ?: return@withCoroutineScope createNotFound(createNotFoundMessage(CLIENT_APP, clientAppId))
@@ -110,7 +110,7 @@ class ClientAppApiImpl: ClientAppsApi, AbstractApi() {
     }
 
     override fun verifyClientApp(verifyClientAppRequest: VerifyClientAppRequest): Uni<Response> = withCoroutineScope {
-        if (requestApiKey != apiKey) return@withCoroutineScope createForbidden(INVALID_API_KEY)
+        if (requestDriverAppKey != driverAppKeyValue) return@withCoroutineScope createForbidden(INVALID_API_KEY)
 
         if (verifyClientAppRequest.deviceId == null) return@withCoroutineScope createBadRequest("Device ID is required")
         val clientApp = clientAppController.find(verifyClientAppRequest.deviceId) ?: return@withCoroutineScope createOk(false)

--- a/src/main/kotlin/fi/metatavu/vp/usermanagement/rest/AbstractApi.kt
+++ b/src/main/kotlin/fi/metatavu/vp/usermanagement/rest/AbstractApi.kt
@@ -25,8 +25,8 @@ abstract class AbstractApi: WithCoroutineScope() {
     @Context
     lateinit var headers: HttpHeaders
 
-    @ConfigProperty(name = "vp.vehiclemanagement.telematics.apiKey")
-    lateinit var apiKey: String
+    @ConfigProperty(name = "vp.usermanagement.app.apiKey")
+    lateinit var driverAppKeyValue: String
 
     @Context
     lateinit var securityContext: SecurityContext
@@ -51,9 +51,9 @@ abstract class AbstractApi: WithCoroutineScope() {
      *
      * @return request api key
      */
-    protected val requestApiKey: String?
+    protected val requestDriverAppKey: String?
         get() {
-            return headers.getHeaderString("X-API-Key")
+            return headers.getHeaderString("X-DriverApp-API-Key")
         }
 
     /**

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/TestBuilder.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/TestBuilder.kt
@@ -38,7 +38,7 @@ class TestBuilder(private val config: Map<String, String>): AbstractAccessTokenT
      */
     fun setApiKey(apiKey: String? = null): TestBuilderAuthentication {
         val key = apiKey ?: "test-api-key"
-        return TestBuilderAuthentication(this, NullAccessTokenProvider(), apiKey = key)
+        return TestBuilderAuthentication(this, NullAccessTokenProvider(), driverAppApiKey = key)
     }
 
     /**

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/auth/TestBuilderAuthentication.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/auth/TestBuilderAuthentication.kt
@@ -15,22 +15,23 @@ import fi.metatavu.vp.usermanagement.impl.*
  *
  * @param testBuilder test builder instance
  * @param accessTokenProvider access token provider
- * @param apiKey api key
+ * @param driverAppApiKey driver app api key
+ * @param cronKey cron key
  */
 class TestBuilderAuthentication(
     private val testBuilder: TestBuilder,
     val accessTokenProvider: AccessTokenProvider,
-    private val apiKey: String? = null,
+    private val driverAppApiKey: String? = null,
     private val cronKey: String? = null
 ) : AccessTokenTestBuilderAuthentication<ApiClient>(testBuilder, accessTokenProvider) {
 
-    val drivers = DriverTestBuilderResource(testBuilder, accessTokenProvider, this.apiKey, createClient(accessTokenProvider))
+    val drivers = DriverTestBuilderResource(testBuilder, accessTokenProvider,createClient(accessTokenProvider))
     val employees = EmployeeTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val workEvents = WorkEventTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val holidays = HolidayTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
     val workShifts = WorkShiftTestBuilderResource(testBuilder, accessTokenProvider, this.cronKey, createClient(accessTokenProvider))
     val workShiftHours = WorkShiftHoursTestBuilderResource(testBuilder, accessTokenProvider, createClient(accessTokenProvider))
-    val clientApps = ClientAppTestBuilderResource(testBuilder, accessTokenProvider, this.apiKey, createClient(accessTokenProvider))
+    val clientApps = ClientAppTestBuilderResource(testBuilder, accessTokenProvider, this.driverAppApiKey, createClient(accessTokenProvider))
 
     override fun createClient(authProvider: AccessTokenProvider): ApiClient {
         val result = ApiClient(ApiTestSettings.apiBasePath)

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/ClientAppTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/ClientAppTestBuilderResource.kt
@@ -31,7 +31,7 @@ class ClientAppTestBuilderResource(
 
     override fun getApi(): ClientAppsApi {
         if (apiKey != null) {
-            ApiClient.apiKey["X-API-Key"] = apiKey
+            ApiClient.apiKey["X-DriverApp-API-Key"] = apiKey
         }
 
         ApiClient.accessToken = accessTokenProvider?.accessToken

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/ClientAppTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/ClientAppTestBuilderResource.kt
@@ -16,13 +16,13 @@ import java.util.*
  *
  * @param testBuilder test builder
  * @param accessTokenProvider access token provider
- * @param apiKey api key
+ * @param driverAppApiKey api key
  * @param apiClient api client
  */
 class ClientAppTestBuilderResource(
     private val testBuilder: TestBuilder,
     private val accessTokenProvider: AccessTokenProvider?,
-    private val apiKey: String?,
+    private val driverAppApiKey: String?,
     apiClient: ApiClient
 ): ApiTestBuilderResource<ClientApp, ApiClient>(testBuilder, apiClient) {
     override fun clean(t: ClientApp) {
@@ -30,8 +30,8 @@ class ClientAppTestBuilderResource(
     }
 
     override fun getApi(): ClientAppsApi {
-        if (apiKey != null) {
-            ApiClient.apiKey["X-DriverApp-API-Key"] = apiKey
+        if (driverAppApiKey != null) {
+            ApiClient.apiKey["X-DriverApp-API-Key"] = driverAppApiKey
         }
 
         ApiClient.accessToken = accessTokenProvider?.accessToken

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/DriverTestBuilderResource.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/impl/DriverTestBuilderResource.kt
@@ -15,13 +15,11 @@ import java.util.UUID
  *
  * @param testBuilder test builder
  * @param accessTokenProvider access token provider
- * @param apiKey api key
  * @param apiClient api client
  */
 class DriverTestBuilderResource(
     testBuilder: TestBuilder,
     private val accessTokenProvider: AccessTokenProvider?,
-    private val apiKey: String?,
     apiClient: ApiClient
 ) : ApiTestBuilderResource<Driver, ApiClient>(testBuilder, apiClient) {
 
@@ -30,9 +28,6 @@ class DriverTestBuilderResource(
     }
 
     override fun getApi(): DriversApi {
-        if (apiKey != null) {
-            ApiClient.apiKey["X-API-Key"] = apiKey
-        }
         ApiClient.accessToken = accessTokenProvider?.accessToken
         return DriversApi(ApiTestSettings.apiBasePath)
     }

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/settings/DefaultTestProfile.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/settings/DefaultTestProfile.kt
@@ -13,7 +13,7 @@ class DefaultTestProfile: QuarkusTestProfile {
         config["vp.keycloak.admin.client"] = "api"
         config["vp.keycloak.admin.user"] = "admin"
         config["vp.keycloak.admin.password"] = "test"
-        config["vp.vehiclemanagement.telematics.apiKey"] = "test-api-key"
+        config["vp.usermanagement.app.apiKey"] = "test-api-key"
         config["vp.usermanagement.cron.apiKey"] = "test-cron-key"
         config["env"] = "TEST"
         return config

--- a/src/test/kotlin/fi/metatavu/vp/usermanagement/settings/RabbitMQTestProfile.kt
+++ b/src/test/kotlin/fi/metatavu/vp/usermanagement/settings/RabbitMQTestProfile.kt
@@ -14,7 +14,7 @@ class RabbitMQTestProfile: QuarkusTestProfile {
         config["vp.keycloak.admin.user"] = "admin"
         config["vp.keycloak.admin.password"] = "test"
         config["workShiftHours.recalculate.interval"] = "1s"
-        config["vp.vehiclemanagement.telematics.apiKey"] = "test-api-key"
+        config["vp.usermanagement.app.apiKey"] = "test-api-key"
         config["vp.usermanagement.cron.apiKey"] = "test-cron-key"
 
         config["mp.messaging.incoming.vp-in.connector"] = "smallrye-rabbitmq"


### PR DESCRIPTION
https://github.com/Metatavu/vp-kuljetus-user-management-service-api/issues/70

Specs changes according to: https://github.com/Metatavu/vp-kuljetus-transport-management-specs/pull/140

- Replaced variable `vp.vehiclemanagement.telematics.apiKey` with `vp.usermanagement.app.apiKey`
- Replaced X-API-Key header with Driver app api header name

